### PR TITLE
korrektes Font Cache-Verzeichnis nutzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Sofern dann an eine aufgerufenen URL **?pdf=1** angehängt wird, wird der Inhalt
 	      $dompdf = new Dompdf\Dompdf($options);
 	      $dompdf->set_option('defaultFont', 'Helvetica');
 	      $dompdf->set_option('dpi', '100');
-		  $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
+	      $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
 		  $dompdf->setPaper('A4', 'portrait');
 
 	      // Inhalte laden und rendern

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ if ($print_pdf) {
 	      // Dompdf konfigurieren
 	      $dompdf = new Dompdf\Dompdf($options);
 	      $dompdf->set_option('defaultFont', 'Helvetica');
-		  $dompdf->set_option('dpi', '100');
+	      $dompdf->set_option('dpi', '100');
 		  $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
 
 	      $dompdf->setPaper('A4', 'portrait');

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Sofern dann an eine aufgerufenen URL **?pdf=1** angehängt wird, wird der Inhalt
 	      $dompdf = new Dompdf\Dompdf($options);
 	      $dompdf->set_option('defaultFont', 'Helvetica');
 	      $dompdf->set_option('dpi', '100');
-	      $dompdf->setPaper('A4', 'portrait');
-	      
+		  $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
+		  $dompdf->setPaper('A4', 'portrait');
+
 	      // Inhalte laden und rendern
 	      $dompdf->loadHtml($pdfcontent);
 	      $dompdf->render();
@@ -130,7 +131,9 @@ if ($print_pdf) {
 	      // Dompdf konfigurieren
 	      $dompdf = new Dompdf\Dompdf($options);
 	      $dompdf->set_option('defaultFont', 'Helvetica');
-	      $dompdf->set_option('dpi', '100');
+		  $dompdf->set_option('dpi', '100');
+		  $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
+
 	      $dompdf->setPaper('A4', 'portrait');
 	      // Inhalte laden und rendern
 	      $dompdf->loadHtml($pre.$pdfcontent.'</body>');
@@ -169,6 +172,7 @@ header('Content-Type: application/pdf');
 $options = new Dompdf\Options();
 $options->set('defaultFont', 'Helvetica');
 $options->set('isRemoteEnabled', TRUE);
+$options->set('font_cache', rex_path::addonCache('pdfout', 'fonts'));
 $dompdf = new Dompdf\Dompdf($options);
 $dompdf->loadHtml($pre.$pdfcontent.'</body>');
 $dompdf->setPaper('A4', 'portrait');

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Sofern dann an eine aufgerufenen URL **?pdf=1** angehängt wird, wird der Inhalt
 	      $dompdf->set_option('defaultFont', 'Helvetica');
 	      $dompdf->set_option('dpi', '100');
 	      $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
-		  $dompdf->setPaper('A4', 'portrait');
+	      $dompdf->setPaper('A4', 'portrait');
 
 	      // Inhalte laden und rendern
 	      $dompdf->loadHtml($pdfcontent);

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ if ($print_pdf) {
 	      $dompdf = new Dompdf\Dompdf($options);
 	      $dompdf->set_option('defaultFont', 'Helvetica');
 	      $dompdf->set_option('dpi', '100');
-		  $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
+	      $dompdf->set_option('font_cache', rex_path::addonCache('pdfout', 'fonts'));
 
 	      $dompdf->setPaper('A4', 'portrait');
 	      // Inhalte laden und rendern

--- a/install.php
+++ b/install.php
@@ -1,0 +1,3 @@
+<?php
+
+rex_dir::create(rex_path::addonCache('pdfout', 'fonts'));

--- a/update.php
+++ b/update.php
@@ -1,0 +1,3 @@
+<?php
+
+rex_dir::create(rex_path::addonCache('pdfout', 'fonts'));


### PR DESCRIPTION
closes #37 

ungetestet. Bitte überprüfen. Änderungen am Modul/Template beachten