### PR TITLE
Update pdfout.php

### DIFF
--- a/lib/pdfout.php
+++ b/lib/pdfout.php
@@ -98,7 +98,9 @@ class PdfOut extends Dompdf
                 rex_file::put($this->saveToPath . rex_string::normalize($this->name) . '.pdf', $savedata);
             }
         }
-        die();
+        else {
+            die();
+        }
     }
 
     /**


### PR DESCRIPTION
Wenn die Property `saveToPath` NICHT gesetzt ist, dann wird trotz erfolgreichem Durchlauf (ohne Fehler) der Programmablauf abgebrochen. Das führte zu dem Fehler, dass nach dem Aufruf von `$pdf->run();` Folge-Code nicht berücksichtig wurde... Dieser PR behebt das Problem und der Programmablauf wird nach erfolgreichem Durchlauf nicht mehr abgebrochen!

Danke an @skerbis für den Wink mit dem ganzen Zaun... ;)
