### PR TITLE
Tamplating and Content

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -19,15 +19,16 @@ if (rex::isBackend() && rex::getUser() !== null) {
                 ->setOrientation('portrait')
                 ->setAttachment(false)
                 ->setRemoteFiles(false);
-            // Setze ein Grundtemplate
-            $pdf->setBaseTemplate('
+// Setze ein Grundtemplate
+$pdf->setBaseTemplate('
 <!DOCTYPE html>
 <html>
 <head>
     <title>Mein PDF</title>
     <style>
         body { font-family: Arial, sans-serif; }
-        .header { background-color: #000; color: #fff; padding: 10px; }
+        .header { background-color: #f0f0f0; padding: 10px; }
+        .footer { text-align: center; margin-top: 20px; }
     </style>
 </head>
 <body>
@@ -38,8 +39,8 @@ if (rex::isBackend() && rex::getUser() !== null) {
 </body>
 </html>
 ');
-
-            // execute and generate
+            
+// execute and generate
             $pdf->run();
         }
     }

--- a/boot.php
+++ b/boot.php
@@ -19,7 +19,31 @@ if (rex::isBackend() && rex::getUser() !== null) {
                 ->setOrientation('portrait')
                 ->setAttachment(false)
                 ->setRemoteFiles(false);
-            // execute and generate
+// Setze ein Grundtemplate
+$pdf->setBaseTemplate('
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mein PDF</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .header { background-color: #f0f0f0; padding: 10px; }
+        .footer { text-align: center; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PDFOut</h1>
+    </div>
+    {{CONTENT}}
+    <div class="footer">
+        <p>Seite 1 von DOMPDF_PAGE_COUNT_PLACEHOLDER</p>
+    </div>
+</body>
+</html>
+');
+            
+// execute and generate
             $pdf->run();
         }
     }

--- a/boot.php
+++ b/boot.php
@@ -19,16 +19,15 @@ if (rex::isBackend() && rex::getUser() !== null) {
                 ->setOrientation('portrait')
                 ->setAttachment(false)
                 ->setRemoteFiles(false);
-// Setze ein Grundtemplate
-$pdf->setBaseTemplate('
+            // Setze ein Grundtemplate
+            $pdf->setBaseTemplate('
 <!DOCTYPE html>
 <html>
 <head>
     <title>Mein PDF</title>
     <style>
         body { font-family: Arial, sans-serif; }
-        .header { background-color: #f0f0f0; padding: 10px; }
-        .footer { text-align: center; margin-top: 20px; }
+        .header { background-color: #000; color: #fff; padding: 10px; }
     </style>
 </head>
 <body>
@@ -36,14 +35,11 @@ $pdf->setBaseTemplate('
         <h1>PDFOut</h1>
     </div>
     {{CONTENT}}
-    <div class="footer">
-        <p>Seite 1 von DOMPDF_PAGE_COUNT_PLACEHOLDER</p>
-    </div>
 </body>
 </html>
 ');
-            
-// execute and generate
+
+            // execute and generate
             $pdf->run();
         }
     }

--- a/lib/pdfout.php
+++ b/lib/pdfout.php
@@ -1,25 +1,57 @@
 <?php
-
 use Dompdf\Dompdf;
 
+/**
+ * PdfOut-Klasse zur Erstellung von PDF-Dokumenten in REDAXO
+ * 
+ * Diese Klasse erweitert Dompdf und bietet zusätzliche Funktionen
+ * zur einfachen Erstellung von PDF-Dokumenten im REDAXO-Kontext.
+ */
 class PdfOut extends Dompdf
 {
+    /** @var string Name der PDF-Datei */
     protected $name = 'pdf_file';
+
+    /** @var string HTML-Inhalt des PDFs */
     protected $html = '';
+
+    /** @var string Ausrichtung des PDFs (portrait/landscape) */
     protected $orientation = 'portrait';
+
+    /** @var string Zu verwendende Schriftart */
     protected $font = 'Dejavu Sans';
+
+    /** @var bool Ob das PDF als Anhang gesendet werden soll */
     protected $attachment = false;
+
+    /** @var bool Ob entfernte Dateien (z.B. Bilder) erlaubt sind */
     protected $remoteFiles = true;
+
+    /** @var string Pfad zum Speichern des PDFs */
     protected $saveToPath = '';
+
+    /** @var int DPI-Einstellung für das PDF */
     protected $dpi = 100;
+
+    /** @var bool Ob das PDF gespeichert und gesendet werden soll */
     protected $saveAndSend = true;
 
+    /** @var string Optionales Grundtemplate für das PDF */
+    protected $baseTemplate = '';
+
+    /** @var string Platzhalter für den Inhalt im Grundtemplate */
+    protected $contentPlaceholder = '{{CONTENT}}';
+
+    /**
+     * Ersetzt den Platzhalter für die Seitenzahl im PDF
+     *
+     * @param Dompdf $dompdf Das Dompdf-Objekt
+     */
     private function injectPageCount(Dompdf $dompdf): void
     {
         /** @var CPDF $canvas */
         $canvas = $dompdf->getCanvas();
         $pdf = $canvas->get_cpdf();
-
         foreach ($pdf->objects as &$o) {
             if ($o['t'] === 'contents') {
                 $o['c'] = str_replace('DOMPDF_PAGE_COUNT_PLACEHOLDER', $canvas->get_page_count(), $o['c']);
@@ -27,12 +59,25 @@ class PdfOut extends Dompdf
         }
     }
 
+    /**
+     * Setzt den Namen der PDF-Datei
+     *
+     * @param string $name Der Name der PDF-Datei
+     * @return self
+     */
     public function setName(string $name): self
     {
         $this->name = $name;
         return $this;
     }
 
+    /**
+     * Setzt den HTML-Inhalt des PDFs
+     *
+     * @param string $html Der HTML-Inhalt
+     * @param bool $outputfilter Optional: Ob der Outputfilter angewendet werden soll
+     * @return self
+     */
     public function setHtml(string $html, bool $outputfilter = false): self
     {
         if ($outputfilter) {
@@ -42,42 +87,84 @@ class PdfOut extends Dompdf
         return $this;
     }
 
+    /**
+     * Setzt die Ausrichtung des PDFs
+     *
+     * @param string $orientation Die Ausrichtung (portrait/landscape)
+     * @return self
+     */
     public function setOrientation(string $orientation): self
     {
         $this->orientation = $orientation;
         return $this;
     }
 
+    /**
+     * Setzt die zu verwendende Schriftart
+     *
+     * @param string $font Die Schriftart
+     * @return self
+     */
     public function setFont(string $font): self
     {
         $this->font = $font;
         return $this;
     }
 
+    /**
+     * Legt fest, ob das PDF als Anhang gesendet werden soll
+     *
+     * @param bool $attachment Ob als Anhang gesendet werden soll
+     * @return self
+     */
     public function setAttachment(bool $attachment): self
     {
         $this->attachment = $attachment;
         return $this;
     }
 
+    /**
+     * Legt fest, ob entfernte Dateien erlaubt sind
+     *
+     * @param bool $remoteFiles Ob entfernte Dateien erlaubt sind
+     * @return self
+     */
     public function setRemoteFiles(bool $remoteFiles): self
     {
         $this->remoteFiles = $remoteFiles;
         return $this;
     }
 
+    /**
+     * Setzt den Pfad zum Speichern des PDFs
+     *
+     * @param string $saveToPath Der Speicherpfad
+     * @return self
+     */
     public function setSaveToPath(string $saveToPath): self
     {
         $this->saveToPath = $saveToPath;
         return $this;
     }
 
+    /**
+     * Setzt die DPI-Einstellung für das PDF
+     *
+     * @param int $dpi Der DPI-Wert
+     * @return self
+     */
     public function setDpi(int $dpi): self
     {
         $this->dpi = $dpi;
         return $this;
     }
 
+    /**
+     * Legt fest, ob das PDF gespeichert und gesendet werden soll
+     *
+     * @param bool $saveAndSend Ob gespeichert und gesendet werden soll
+     * @return self
+     */
     public function setSaveAndSend(bool $saveAndSend): self
     {
         $this->saveAndSend = $saveAndSend;
@@ -85,12 +172,26 @@ class PdfOut extends Dompdf
     }
 
     /**
-    * Fügt den Inhalt eines REDAXO-Artikels zum PDF hinzu
-    *
-    * @param int $articleId Die ID des Artikels
-    * @param int|null $ctype Optional: Die ID des Inhaltstyps (ctype)
-    * @return self
-    */
+     * Setzt ein optionales Grundtemplate für das PDF
+     *
+     * @param string $template Das HTML-Template
+     * @param string $placeholder Optional: Der Platzhalter für den Inhalt
+     * @return self
+     */
+    public function setBaseTemplate(string $template, string $placeholder = '{{CONTENT}}'): self
+    {
+        $this->baseTemplate = $template;
+        $this->contentPlaceholder = $placeholder;
+        return $this;
+    }
+
+    /**
+     * Fügt den Inhalt eines REDAXO-Artikels zum PDF hinzu
+     *
+     * @param int $articleId Die ID des Artikels
+     * @param int|null $ctype Optional: Die ID des Inhaltstyps (ctype)
+     * @return self
+     */
     public function addArticle(int $articleId, ?int $ctype = null): self
     {
         $article = rex_article::get($articleId);
@@ -101,9 +202,20 @@ class PdfOut extends Dompdf
         return $this;
     }
 
+    /**
+     * Führt die PDF-Erstellung aus
+     */
     public function run(): void
     {
-        $this->loadHtml($this->html);
+        $finalHtml = $this->html;
+
+        // Wenn ein Grundtemplate gesetzt wurde, füge den Inhalt ein
+        if ($this->baseTemplate !== '') {
+            $finalHtml = str_replace($this->contentPlaceholder, $this->html, $this->baseTemplate);
+        }
+
+        $this->loadHtml($finalHtml);
+
         // Optionen festlegen
         $options = $this->getOptions();
         $options->setChroot(rex_path::frontend());
@@ -112,13 +224,16 @@ class PdfOut extends Dompdf
         $options->setFontCache(rex_path::addonCache('pdfout', 'fonts'));
         $options->setIsRemoteEnabled($this->remoteFiles);
         $this->setOptions($options);
+
         $this->setPaper('A4', $this->orientation);
-        // Rendern des PDF
+
+        // Rendern des PDFs
         $this->render();
-        // Pagecounter Placeholder esetzen, wenn vorhanden
+
+        // Pagecounter Placeholder ersetzen, wenn vorhanden
         $this->injectPageCount($this);
 
-        // Speichern des PDF 
+        // Speichern des PDFs 
         if ($this->saveToPath !== '') {
             $savedata = $this->output();
             if (!is_null($savedata)) {
@@ -126,18 +241,25 @@ class PdfOut extends Dompdf
             }
         }
 
-        // Ausliefern des PDF
+        // Ausliefern des PDFs
         if ($this->saveToPath === '' || $this->saveAndSend === true) {
             rex_response::cleanOutputBuffers(); // OutputBuffer leeren
             header('Content-Type: application/pdf');
             $this->stream(rex_string::normalize($this->name), array('Attachment' => $this->attachment));
-            die();
+            exit();
         }
     }
 
+    /**
+     * Generiert eine URL für ein Media-Element
+     *
+     * @param string $type Der Media Manager Typ
+     * @param string $file Der Dateiname
+     * @return string Die generierte URL
+     */
     public static function mediaUrl(string $type, string $file): string
     {
-        $paddon = rex_addon::get('pdfout');
+        $addon = rex_addon::get('pdfout');
         $url = rex_media_manager::getUrl($type, $file);
         if ($addon->getProperty('aspdf', false) || rex_request('pdfout', 'int', 0) === 1) {
             return rex::getServer() . $url;
@@ -145,6 +267,12 @@ class PdfOut extends Dompdf
         return $url;
     }
 
+    /**
+     * Generiert eine URL für den PDF-Viewer
+     *
+     * @param string $file Optional: Die anzuzeigende PDF-Datei
+     * @return string Die generierte URL
+     */
     public static function viewer(string $file = ''): string
     {
         if ($file !== '') {


### PR DESCRIPTION
# Erweiterung der PdfOut-Klasse: Grundtemplate und REDAXO-Artikel-Integration

## Zusammenfassung
Dieser PR erweitert die `PdfOut`-Klasse um zwei wichtige Funktionen:
1. Unterstützung für ein optionales Grundtemplate
2. Direkte Integration von REDAXO-Artikeln

## Änderungen im Detail

### Neue Funktionen:
- `setBaseTemplate($template, $placeholder)`: Ermöglicht das Setzen eines HTML-Grundtemplates für das PDF.
- `addArticle($articleId, $ctype = null)`: Fügt den Inhalt eines REDAXO-Artikels direkt zum PDF hinzu.

### Anpassungen:
- Die `run()`-Methode wurde aktualisiert, um das optionale Grundtemplate zu berücksichtigen.
- Umfangreiche PHPDoc-Kommentare wurden hinzugefügt, um die Verwendung der Klasse zu erleichtern.

## Begründung
Diese Erweiterungen bieten mehr Flexibilität bei der PDF-Erstellung:
- Das Grundtemplate ermöglicht eine konsistente Gestaltung über mehrere PDFs hinweg.
- Die direkte Integration von REDAXO-Artikeln vereinfacht den Workflow bei der Erstellung von PDFs aus bestehenden Inhalten.

## Auswirkungen
- Bestehender Code, der die `PdfOut`-Klasse verwendet, sollte ohne Änderungen weiterhin funktionieren.
- Die neuen Funktionen sind optional und beeinträchtigen die bisherige Funktionalität nicht.

## Beispielverwendung

```php
$pdf = new PdfOut();
$pdf->setBaseTemplate('<!DOCTYPE html><html><body><header>Meine Kopfzeile</header>{{CONTENT}}<footer>Meine Fußzeile</footer></body></html>')
   ->addArticle(1)
   ->setHtml('<p>Zusätzlicher Inhalt</p>')
   ->run();
   
## Beispiel 2

// Setze ein Grundtemplate
$pdf->setBaseTemplate('
<!DOCTYPE html>
<html>
<head>
    <title>Mein PDF</title>
    <style>
        body { font-family: Arial, sans-serif; }
        .header { background-color: #f0f0f0; padding: 10px; }
        .footer { text-align: center; margin-top: 20px; }
    </style>
</head>
<body>
    <div class="header">
        <h1>Mein Unternehmen</h1>
    </div>
    {{CONTENT}}
    <div class="footer">
        <p>Seite 1 von DOMPDF_PAGE_COUNT_PLACEHOLDER</p>
    </div>
</body>
</html>
');

// Füge Inhalte hinzu
$pdf->addArticle(1)
    ->addArticle(2, 1)
    ->setHtml('<p>Zusätzlicher HTML-Inhalt</p>')
    ->run();   
   
   