### PR TITLE
erlaube papersize setting

### DIFF
--- a/lib/pdfout.php
+++ b/lib/pdfout.php
@@ -57,6 +57,9 @@ class PdfOut extends Dompdf
     /** @var string Platzhalter für den Inhalt im Grundtemplate */
     protected $contentPlaceholder = '{{CONTENT}}';
 
+    /** @var string Papierformat für das PDF */
+    protected $paperSize = 'A4';
+
     /**
      * Ersetzt den Platzhalter für die Seitenzahl im PDF
      *
@@ -72,6 +75,20 @@ class PdfOut extends Dompdf
                 $o['c'] = str_replace('DOMPDF_PAGE_COUNT_PLACEHOLDER', $canvas->get_page_count(), $o['c']);
             }
         }
+    }
+
+    /**
+     * Setzt das Papierformat und die Ausrichtung für das PDF
+     *
+     * @param string $size Das Papierformat (z.B. 'A4', 'letter', oder [width, height] in points)
+     * @param string $orientation Die Ausrichtung (portrait/landscape)
+     * @return self
+     */
+    public function setPaperSize(string|array $size = 'A4', string $orientation = 'portrait'): self
+    {
+        $this->paperSize = $size;
+        $this->orientation = $orientation;
+        return $this;
     }
 
     /**
@@ -255,7 +272,8 @@ class PdfOut extends Dompdf
         $options->setIsRemoteEnabled($this->remoteFiles);
         $this->setOptions($options);
 
-        $this->setPaper('A4', $this->orientation);
+        // Papierformat und Ausrichtung setzen
+        $this->setPaper($this->paperSize, $this->orientation);
 
         // Rendern des PDFs
         $this->render();


### PR DESCRIPTION
# Flexibles Paper-Format für PDFs

Diese Änderung ermöglicht es, das Papierformat und die Orientierung für PDFs flexibler zu setzen, während die bisherigen Standardwerte (A4, portrait) erhalten bleiben.

## Änderungen

- Neue Property `$paperSize` für das Papierformat
- Neue Methode `setPaperSize()` zum Setzen von Format und Orientierung
- Bisherige Standardwerte (A4, portrait) bleiben erhalten
- Unterstützung für Standard-Formate und benutzerdefinierte Größen

## Beispiele

```php
// Bisherige Verwendung bleibt unverändert - nutzt A4 im Hochformat
$pdf = new PdfOut();
$pdf
    ->setHtml($html)
    ->run();

// Neues Format setzen - z.B. US Letter im Querformat
$pdf = new PdfOut();
$pdf
    ->setPaperSize('letter', 'landscape')
    ->setHtml($html)
    ->run();

// Benutzerdefinierte Größe (z.B. für Visitenkarten)
$pdf = new PdfOut();
$pdf
    ->setPaperSize([0, 0, 252, 144]) // 3.5x2 Zoll in Punkten (72 Punkte pro Zoll)
    ->setHtml($html)
    ->run();

// Komplexeres Beispiel mit mehreren Optionen
$pdf = new PdfOut();
$pdf
    ->setName('visitenkarte')
    ->setPaperSize([0, 0, 252, 144])
    ->setDpi(300) // Hohe Auflösung für Druck
    ->setFont('Helvetica')
    ->setHtml($html)
    ->setSaveToPath('/path/to/save/')
    ->run();
```

## Unterstützte Papierformate

Die Methode unterstützt alle von Dompdf unterstützten Formate:
- Standard-Formate: 'letter', 'legal', 'A4', 'A3', etc.
- Benutzerdefinierte Größen als Array: `[left, top, right, bottom]` in Punkten
- Orientierung: 'portrait' oder 'landscape'

## Warum ist diese Änderung wichtig?

1. **Flexibilität**: Ermöglicht die Erstellung von PDFs in verschiedenen Formaten ohne die Standardfunktionalität zu ändern
2. **Rückwärtskompatibilität**: Bestehender Code funktioniert weiterhin wie gewohnt
3. **Bessere API**: Klare, dedizierte Methode zum Setzen des Formats
4. **Spezielle Formate**: Unterstützt Sonderformate wie Visitenkarten, Etiketten etc.

## Breaking Changes

Keine. Alle bestehenden Implementierungen funktionieren weiterhin wie bisher.